### PR TITLE
Add http caching middleware

### DIFF
--- a/pkg/cache/cacheable.go
+++ b/pkg/cache/cacheable.go
@@ -65,11 +65,11 @@ var (
 	}
 )
 
-// CanServeRequestFromCache checks if a request can be served from cache.
+// IsCacheableRequest checks if a request can be served from cache.
 // This does not depend on cache-control headers as request cache-control
 // headers only decide whether validation is required and whether the
 // response can be cached.
-func CanServeRequestFromCache(req *http.Request) bool {
+func IsCacheableRequest(req *http.Request) bool {
 	// Check if the request contains any conditional headers.
 	// For now, requests with conditional headers bypass the cache.
 	for _, h := range conditionalHeaders {

--- a/pkg/cache/cacheable_test.go
+++ b/pkg/cache/cacheable_test.go
@@ -29,38 +29,38 @@ func setupResponse(t *testing.T) {
 func TestCanServeRequestFromCache(t *testing.T) {
 	t.Run("Cacheable request", func(t *testing.T) {
 		setupRequest(t)
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 	})
 	t.Run("Path", func(t *testing.T) {
 		setupRequest(t)
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 		req.URL.Path = ""
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 	})
 	t.Run("Host", func(t *testing.T) {
 		setupRequest(t)
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 		req.Host = ""
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 	})
 	t.Run("Method", func(t *testing.T) {
 		setupRequest(t)
 		req.Method = http.MethodGet
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 		req.Method = http.MethodHead
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 		req.Method = http.MethodPost
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 		req.Method = http.MethodPut
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 		req.Method = ""
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 	})
 	t.Run("Authorization header", func(t *testing.T) {
 		setupRequest(t)
-		assert.True(t, CanServeRequestFromCache(req))
+		assert.True(t, IsCacheableRequest(req))
 		req.Header.Set(HeaderAuthorization, "Basic bmFtZTpwYXNzd29yZA==")
-		assert.False(t, CanServeRequestFromCache(req))
+		assert.False(t, IsCacheableRequest(req))
 	})
 	t.Run("Conditional headers", func(t *testing.T) {
 		setupRequest(t)
@@ -68,9 +68,9 @@ func TestCanServeRequestFromCache(t *testing.T) {
 			"if-unmodified-since", "if-range"}
 		for _, header := range headers {
 			t.Run(header, func(t *testing.T) {
-				assert.True(t, CanServeRequestFromCache(req))
+				assert.True(t, IsCacheableRequest(req))
 				req.Header.Set(header, "some value")
-				assert.False(t, CanServeRequestFromCache(req))
+				assert.False(t, IsCacheableRequest(req))
 			})
 			req.Header.Del(header)
 		}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -1,82 +1,10 @@
 package server
 
 import (
-	"bufio"
-	"bytes"
-	"context"
 	"encoding/json"
-	"io"
-	"log"
+
 	"net/http"
-	"net/http/httputil"
-	"time"
-
-	"github.com/kacheio/kache/pkg/cache"
 )
-
-// ServeHTTP is the main handler, serving the response
-// from cache, if it exists, or bypassing the request upstream.
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
-	// Check if the response is already in the cache
-
-	log.Println("serving request from proxy: ", r)
-
-	cacheKey := cache.NewKeyFromRequst(r)
-
-	if cached := s.cache.Get(cacheKey.String()); cached != nil {
-
-		log.Println("serving from cache (hit)...")
-		log.Println(cached)
-
-		res, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(cached.(*cache.Entry).Body)), r)
-		if err != nil {
-			log.Println(err)
-		}
-
-		// If the response is in the cache and hasn't been modified, serve it from the cache
-		for k, v := range res.Header {
-			w.Header()[k] = v
-		}
-		w.WriteHeader(res.StatusCode)
-		if _, err := io.Copy(w, res.Body); err != nil {
-			log.Println(err)
-		}
-		return
-	}
-
-	ctx := r.Context()
-	ctx = context.WithValue(ctx, ctxCacheKey{}, cacheKey.String())
-
-	r = r.WithContext(ctx)
-
-	// If the response isn't in the cache, forward the request to the backend servers
-	s.proxy.ServeHTTP(w, r)
-}
-
-// modifyResponse modifies the response from the upstream server.
-func (s *Server) modifyResponse(res *http.Response) error {
-	// log.Println("Upstream response: ", res)
-
-	if response, err := httputil.DumpResponse(res, true); err == nil {
-		log.Println("add response to cache")
-		cacheKey := res.Request.Context().Value(ctxCacheKey{}).(string)
-
-		entry := &cache.Entry{
-			Body:         response,
-			LastModified: time.Now(),
-		}
-		s.cache.Put(cacheKey, entry)
-
-		log.Println("response added to cache: ", s.cache.Size(), s.cache)
-	} else {
-		log.Println(err)
-	}
-
-	return nil
-}
-
-/// Registered API handlers
 
 // CacheKeysHandler renders all cache keys in JSON format.
 func (s *Server) CacheKeysHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/middleware/httpcache.go
+++ b/pkg/server/middleware/httpcache.go
@@ -44,7 +44,7 @@ func NewCachedTransport(p provider.Provider) *Transport {
 func (t *Transport) RoundTrip(ireq *http.Request) (resp *http.Response, err error) {
 	req := ireq // req is either the original request, or a modified fork.
 
-	if !cache.CanServeRequestFromCache(req) {
+	if !cache.IsCacheableRequest(req) {
 		log.Debug().Msgf("Ignoring uncachable request: %v", req)
 		return t.send(req)
 	}

--- a/pkg/server/middleware/httpcache.go
+++ b/pkg/server/middleware/httpcache.go
@@ -1,0 +1,154 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/kacheio/kache/pkg/cache"
+	"github.com/kacheio/kache/pkg/provider"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	XCache = "X-Kache"
+	HIT    = "HIT"
+)
+
+// Transport is the http filter implementing the http caching logic.
+type Transport struct {
+	// The RoundTripper interface actually used to make requests.
+	// If nil, http.DefaultTransport is used.
+	Transport http.RoundTripper
+
+	// Cache is the http cache.
+	Cache *cache.HttpCache
+
+	// If true, responses returned from the cache will be given an extra header.
+	MarkCachedResponses bool
+
+	// currentTime holds the time source.
+	currentTime func() time.Time
+}
+
+// NewTransport returns a new Transport with the provided Cache implementation.
+func NewCachedTransport(p provider.Provider) *Transport {
+	c, err := cache.NewHttpCache(p)
+	if err != nil {
+		return nil
+	}
+	return &Transport{Cache: c, MarkCachedResponses: true, currentTime: time.Now}
+}
+
+// RoundTrip issues a http roundtrip and applies the http caching logic.
+func (t *Transport) RoundTrip(ireq *http.Request) (resp *http.Response, err error) {
+	req := ireq // req is either the original request, or a modified fork.
+
+	if !cache.CanServeRequestFromCache(req) {
+		log.Debug().Msgf("Ignoring uncachable request: %v", req)
+		return t.send(req)
+	}
+
+	lookupReq := cache.NewLookupRequest(req, t.currentTime())
+	cachedRes := t.Cache.FetchResponse(context.Background(), *lookupReq)
+
+	switch cachedRes.Status {
+	case cache.EntryOk:
+		cachedRes.Header().Set(XCache, HIT)
+		return cachedRes.Response(), nil
+
+	case cache.EntryRequiresValidation:
+		cachedRes.Header().Set(XCache, HIT)
+
+		// forkReq forks req into a shallow clone of ireq the first
+		// time it's called.
+		forkReq := func() {
+			if ireq == req {
+				req = new(http.Request)
+				*req = *ireq // shallow clone
+				// Copy the initial request's Header
+				req.Header = make(http.Header)
+				for k, vv := range ireq.Header {
+					req.Header[k] = vv
+				}
+			}
+		}
+
+		// Inject validation headers.
+		if etag := cachedRes.Header().Get(cache.HeaderEtag); etag != "" {
+			forkReq()
+			req.Header.Set(cache.HeaderIfNoneMatch, etag)
+		}
+		if lastModified := cachedRes.Header().Get(cache.HeaderLastModified); lastModified != "" {
+			forkReq()
+			req.Header.Set(cache.HeaderIfModifiedSince, lastModified)
+		} else {
+			forkReq()
+			// Fallback to Date header if Last-Modified is missing or invalid.
+			// https://httpwg.org/specs/rfc7232.html#header.if-modified-sinces
+			date := cachedRes.Header().Get(cache.HeaderDate)
+			req.Header.Set(cache.HeaderLastModified, date)
+		}
+	}
+
+	// Send request to upstream.
+	resp, err = t.send(req)
+	if err != nil {
+		log.Error().Err(err).Msgf("RoundTrip: error: %v", err)
+		return resp, err
+	}
+
+	shouldUpdateCachedEntry := true
+	if err == nil && resp.StatusCode == http.StatusNotModified &&
+		cachedRes.Status == cache.EntryRequiresValidation {
+		// Process successful validation.
+
+		// If the 304 response contains a strong validator (etag) that does not match
+		// the cached response, the cached response should not be updated.
+		// https://httpwg.org/specs/rfc7234.html#freshening.responses
+		resEtag := resp.Header.Get(cache.HeaderEtag)
+		cacEtag := cachedRes.Header().Get(cache.HeaderEtag)
+		shouldUpdateCachedEntry = (resEtag == "" || (cacEtag != "" && cacEtag == resEtag))
+
+		// A response that has been validated should not contain an Age header
+		// as it is equivalent to a freshly served response from the origin.
+		cachedRes.Header().Del(cache.HeaderAge)
+
+		// Add any missing headers from the 304 to the cached response.
+		// Skip headers that should not be updated upon validation.
+		// https://www.ietf.org/archive/id/draft-ietf-httpbis-cache-18.html (3.2)
+		headersNotToUpdate := map[string]struct{}{
+			"Content-Range":  {}, // should not be changed upon validation.
+			"Content-Length": {}, // should never be updated.
+			"Etag":           {},
+			"Vary":           {},
+		}
+		for k, vv := range resp.Header {
+			if _, ok := headersNotToUpdate[k]; !ok {
+				cachedRes.Header()[k] = vv
+			}
+		}
+
+		resp.Body.Close()
+		resp = cachedRes.Response()
+	}
+
+	// Store new or update validated response.
+	if cache.IsCacheableResponse(resp) && !lookupReq.ReqCacheControl.NoStore &&
+		shouldUpdateCachedEntry && req.Method != "HEAD" {
+		t.Cache.StoreResponse(context.TODO(), *lookupReq, resp)
+	} else {
+		t.Cache.Delete(context.TODO(), *lookupReq)
+	}
+
+	return resp, nil
+}
+
+// send issues an upstream request.
+func (t *Transport) send(req *http.Request) (*http.Response, error) {
+	transport := t.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return transport.RoundTrip(req)
+}

--- a/pkg/server/middleware/httpcache_test.go
+++ b/pkg/server/middleware/httpcache_test.go
@@ -146,7 +146,7 @@ func TestExpiredValidated(t *testing.T) {
 		// Check that the served response is the cached response.
 		assert.Equal(t, "HIT", resp.Header.Get(XCache))
 
-		// A response that has been validated should not contain an Age header 
+		// A response that has been validated should not contain an Age header
 		// as it is equivalent to a freshly served response from the origin.
 		assert.Equal(t, "", resp.Header.Get("Age"))
 	}
@@ -200,7 +200,7 @@ func TestExpiredFetchedNewResponse(t *testing.T) {
 	// Ensure response date header gets updated with the 304 date.
 	advanceTime(11 * time.Second)
 
-	// Send second request, attempted validation of the cached response should fail. The new 
+	// Send second request, attempted validation of the cached response should fail. The new
 	// response should be served.
 	{
 		resp, err := s.client.Do(req)

--- a/pkg/server/middleware/httpcache_test.go
+++ b/pkg/server/middleware/httpcache_test.go
@@ -1,0 +1,456 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kacheio/kache/pkg/provider"
+	"github.com/kacheio/kache/pkg/utils/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var s struct {
+	client    http.Client
+	mux       *http.ServeMux
+	server    *httptest.Server
+	transport *Transport
+}
+
+var (
+	// Fake time source.
+	ts *clock.EventTime
+)
+
+// currentTime returns the fake time.
+func currentTime() time.Time {
+	return ts.Now()
+}
+
+// advanceTime advances time forward by the specified duration.
+func advanceTime(d time.Duration) {
+	ts.Update(ts.Now().Add(d))
+}
+
+func setup(t *testing.T) {
+	ts = clock.NewEventTimeSource()
+	ts.Update(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
+
+	p, _ := provider.NewSimpleCache(nil)
+	tp := NewCachedTransport(p)
+	tp.currentTime = currentTime
+
+	client := http.Client{Transport: tp}
+
+	s.transport = tp
+	s.client = client
+
+	s.mux = http.NewServeMux()
+	s.server = httptest.NewServer(s.mux)
+}
+
+func teardown(t *testing.T) {
+	s.server.Close()
+}
+
+func TestMissInsertHit(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_miss_insert_hit", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		w.Header().Set("Content-length", "2")
+		_, _ = w.Write([]byte("42"))
+	}))
+
+	req, err := http.NewRequest("GET", s.server.URL+"/test_miss_insert_hit", nil)
+	require.NoError(t, err)
+
+	// Send first request, get response from upstream.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "", resp.Header.Get(XCache))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+		assert.Equal(t, "42", string(body))
+	}
+
+	// Advance time.
+	advanceTime(10 * time.Second)
+
+	// Send second request, get response from cache.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "HIT", resp.Header.Get(XCache))
+		assert.Equal(t, "10", resp.Header.Get("Age"))
+		assert.Equal(t, "42", string(body))
+	}
+}
+
+func TestExpiredValidated(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_expired_validated", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("if-none-match") == "abc123" {
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+		w.Header().Set("Cache-Control", "max-age=10")
+		w.Header().Set("Content-length", "2")
+		w.Header().Set("Etag", "abc123")
+		_, _ = w.Write([]byte("42"))
+	}))
+
+	req, err := http.NewRequest("GET", s.server.URL+"/test_expired_validated", nil)
+	require.NoError(t, err)
+
+	// Send first request, get response from upstream.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "", resp.Header.Get("Age"))
+		assert.Equal(t, "42", string(body))
+	}
+
+	// Advance time for the cached response to be stale (expired).
+	// Ensure response date header gets updated with the 304 date.
+	advanceTime(11 * time.Second)
+
+	// Send second request, cached response should be validated, then served.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Check that the served response is the cached response.
+		assert.Equal(t, "HIT", resp.Header.Get(XCache))
+
+		// A response that has been validated should not contain an Age header 
+		// as it is equivalent to a freshly served response from the origin.
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time to get a fresh cached response.
+	advanceTime(1 * time.Second)
+
+	// Send third request. The cached response was validated, thus it should have an Age header.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "1", resp.Header.Get("Age"))
+	}
+}
+
+func TestExpiredFetchedNewResponse(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_expired_fetched_new_response",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("if-none-match") == "a1" {
+				w.Header().Set("Cache-Control", "max-age=10")
+				w.Header().Set("Etag", "a2")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("aaaaaaaaa"))
+				return
+			}
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "max-age=10")
+			w.Header().Set("Content-length", "1")
+			w.Header().Set("Etag", "a1")
+			_, _ = w.Write([]byte("a"))
+		}))
+
+	req, err := http.NewRequest("GET", s.server.URL+"/test_expired_fetched_new_response", nil)
+	require.NoError(t, err)
+
+	// Send first request, and get response from upstream.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time for the cached response to be stale (expired).
+	// Ensure response date header gets updated with the 304 date.
+	advanceTime(11 * time.Second)
+
+	// Send second request, attempted validation of the cached response should fail. The new 
+	// response should be served.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Check that the served response is the new response.
+		assert.Equal(t, "aaaaaaaaa", buf.String())
+
+		// Check that age header does not exist as this is not a cached response.
+		assert.Equal(t, "", resp.Header.Get("Age"))
+		assert.Equal(t, "", resp.Header.Get(XCache))
+	}
+}
+
+func TestServeHeadRequest(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_serve_head_request",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			w.Header().Set("Content-length", "3")
+			w.Header().Set("Etag", "a1")
+			_, _ = w.Write([]byte("aaa"))
+		}))
+
+	req, err := http.NewRequest("HEAD", s.server.URL+"/test_serve_head_request", nil)
+	require.NoError(t, err)
+
+	// Send first request, and get response from upstream.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time, to verify the original date header is preserved.
+	advanceTime(10 * time.Second)
+
+	// Send second request, and get response from upstream, since head requests are not stored
+	// in cache.
+	{
+		resp, err := s.client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+}
+
+func TestServeHeadFromCacheAfterGetRequest(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_serve_head_from_cache_after_get",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			w.Header().Set("Content-length", "3")
+			w.Header().Set("Etag", "a3")
+			_, _ = w.Write([]byte("aaa"))
+		}))
+
+	url := s.server.URL + "/test_serve_head_from_cache_after_get"
+
+	// Send GET request, and get response from upstream.
+	{
+		resp, err := s.client.Get(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "aaa", string(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time, to verify the original date header is preserved.
+	advanceTime(10 * time.Second)
+
+	// Send HEAD request, and get response from cache.
+	{
+		resp, err := s.client.Head(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+		assert.Equal(t, "10", resp.Header.Get("Age"))
+		assert.Equal(t, "HIT", resp.Header.Get(XCache))
+	}
+}
+
+func TestServeGetFromUpstreamAfterHead(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_serve_get_from_upstream_after_head",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			w.Header().Set("Content-length", "3")
+			w.Header().Set("Etag", "a1")
+			_, _ = w.Write([]byte("aaa"))
+		}))
+
+	url := s.server.URL + "/test_serve_get_from_upstream_after_head"
+
+	// Send HEAD request, and get response from upstream.
+	{
+		resp, err := s.client.Head(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Send GET request, and get response from upstream.
+	{
+		resp, err := s.client.Get(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "aaa", string(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+}
+
+func TestServeGetFollowedByHead304WithValidation(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_serve_get_head_validation",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("if-none-match") == "abc123" {
+				w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "max-age=10")
+			w.Header().Set("Content-length", "3")
+			w.Header().Set("Etag", "abc123")
+			_, _ = w.Write([]byte("aaa"))
+		}))
+
+	url := s.server.URL + "/test_serve_get_head_validation"
+
+	// Send GET request, and get response from upstream.
+	{
+		resp, err := s.client.Get(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "aaa", string(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time for the cached response to be stale (expired).
+	// Ensure response date header gets updated with the 304 date.
+	advanceTime(11 * time.Second)
+
+	// Send HEAD request, the cached response should be validated, then served.
+	{
+		resp, err := s.client.Head(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+		assert.Equal(t, "HIT", resp.Header.Get(XCache))
+
+		// A response that has been validated should not contain an Age header.
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+}
+
+func TestServeGetFollowedByHead200WithValidation(t *testing.T) {
+	setup(t)
+	t.Cleanup(func() { teardown(t) })
+
+	s.mux.HandleFunc("/test_serve_get_head_200_validation",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("if-none-match") == "a3" {
+				w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+				w.Header().Set("Cache-Control", "max-age=10")
+				w.Header().Set("Content-length", "9")
+				w.Header().Set("Etag", "a9")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("aaaaaaaaa"))
+				return
+			}
+			w.Header().Set("Date", currentTime().Format(http.TimeFormat))
+			w.Header().Set("Cache-Control", "max-age=10")
+			w.Header().Set("Content-length", "3")
+			w.Header().Set("Etag", "a3")
+			_, _ = w.Write([]byte("aaa"))
+		}))
+
+	url := s.server.URL + "/test_serve_get_head_200_validation"
+
+	// Send GET request, and get response from upstream.
+	{
+		resp, err := s.client.Get(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, "aaa", string(body))
+		assert.Equal(t, "", resp.Header.Get("Age"))
+	}
+
+	// Advance time for the cached response to be stale (expired).
+	advanceTime(11 * time.Second)
+
+	// Send HEAD request, attempted validation of the cached response should fail.
+	{
+		resp, err := s.client.Head(url)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, 0, len(body))
+
+		// Ensure this is not a cached response.
+		assert.Equal(t, "", resp.Header.Get("Age"))
+		assert.Equal(t, "", resp.Header.Get(XCache))
+	}
+}


### PR DESCRIPTION
This PR adds the first version of the basic http caching middleware. The main caching logic is expected to be refactored in future iterations when missing features like vary headers, range requests, etc. are added.