### PR TITLE
Set build platform depending on event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64/v8' || 'linux/amd64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
This change uses a ternary operator to set the value of the build platform variable depending on whether the GitHub event is a PR or not. In a PR event, the build is for testing only and is not pushed to the registry, so it is build for Linux/amd64 only. In a push-to-main event (e.g. a pr merge or release), we build and push for both platforms, linux/amd64 and linux/arm64.

Building for both platforms, especially linux/arm64 takes significantly longer than just building for linux/amd64. We assume that a successful build on arm will also be successful on amd, and vice versa. Therefore, it is sufficient to validate on only one platform (amd).  

However, the multi-platform build time could probably be improved by using a matrix strategy, which requires a more complex configuration. This is something that can be improved and tested in the future. 

