### PR TITLE
Add remote cache job queue

### DIFF
--- a/kache.sample.yml
+++ b/kache.sample.yml
@@ -50,10 +50,13 @@ provider:
     username:
     password:
     db:
+    max_queue_buffer_size:
+    max_queue_concurrency:
 
   # in-memory cache configuration
   inmemory:
     max_size:
     max_item_size:
+
 ## Cluster configuration
 ## TODO

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -63,6 +63,9 @@ type RemoteCacheClient interface {
 	// Returns an error in case the operation fails.
 	Store(key string, value []byte, ttl time.Duration) error
 
+	// StoreAsync asynchronously stores a key and value into the the remote cache.
+	StoreAsync(key string, value []byte, ttl time.Duration) error
+
 	// Delete deletes a key from the remote cache.
 	Delete(ctx context.Context, key string) error
 

--- a/pkg/provider/queue.go
+++ b/pkg/provider/queue.go
@@ -1,0 +1,84 @@
+// MIT License
+//
+// Copyright (c) 2023 kache.io
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"errors"
+	"sync"
+)
+
+var errJobQueueFull = errors.New("job queue is full")
+
+// jobQueue is the concurrent job queue.
+type jobQueue struct {
+	// jobCh is the main event channel listening for jobs.
+	jobCh chan func()
+
+	// stopCh aborts the processing loop.
+	stopCh chan struct{}
+
+	// wg controls the number of consumers/workers.
+	wg sync.WaitGroup
+}
+
+// newJobQueue creates a new queue and starts the processing loop.
+func newJobQueue(size, maxConcurrency int) *jobQueue {
+	q := &jobQueue{
+		jobCh:  make(chan func(), size),
+		stopCh: make(chan struct{}),
+	}
+	q.wg.Add(maxConcurrency)
+	for i := 0; i < maxConcurrency; i++ {
+		go q.listen()
+	}
+	return q
+}
+
+// dispatch enqueues a job for execution.
+func (q *jobQueue) dispatch(job func()) error {
+	select {
+	case q.jobCh <- job:
+		return nil
+	default:
+		return errJobQueueFull
+	}
+}
+
+// stops aborts the processing loop.
+func (q *jobQueue) stop() {
+	close(q.stopCh)
+	q.wg.Wait()
+}
+
+// listen starts the job processing loop.
+func (q *jobQueue) listen() {
+	defer q.wg.Done()
+	for {
+		select {
+		case job := <-q.jobCh:
+			job() // execute job.
+		case <-q.stopCh:
+			return
+		}
+	}
+}

--- a/pkg/provider/queue_test.go
+++ b/pkg/provider/queue_test.go
@@ -1,0 +1,74 @@
+// MIT License
+//
+// Copyright (c) 2023 kache.io
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobQueueRun(t *testing.T) {
+	q := newJobQueue(10, 10)
+	defer q.stop()
+
+	var i atomic.Int32
+	_ = q.dispatch(func() { i.Add(1) })
+	_ = q.dispatch(func() { i.Add(-1) })
+	_ = q.dispatch(func() { i.Add(1) })
+	_ = q.dispatch(func() { i.Add(-1) })
+	_ = q.dispatch(func() { i.Add(1) })
+
+	// Wait for all operations to finish.
+	time.Sleep(100 * time.Millisecond)
+
+	require.Equal(t, int32(1), i.Load())
+}
+
+func TestJobQueueError(t *testing.T) {
+	const queueSize = 10
+
+	q := newJobQueue(queueSize, 1)
+	defer q.stop()
+
+	doneCh := make(chan struct{})
+	defer func() {
+		close(doneCh)
+	}()
+
+	// Keep workers busy.
+	_ = q.dispatch(func() {
+		<-doneCh
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// Enqueue jobs until full.
+	for i := 0; i < queueSize; i++ {
+		require.NoError(t, q.dispatch(func() {}))
+	}
+
+	// Overflow queue.
+	require.Equal(t, errJobQueueFull, q.dispatch(func() {}))
+}

--- a/pkg/provider/redis_client.go
+++ b/pkg/provider/redis_client.go
@@ -163,6 +163,7 @@ func (c *redisClient) Keys(ctx context.Context, prefix string) []string {
 
 // Stop client and release resources.
 func (c *redisClient) Stop() {
+	c.queue.stop()
 	if err := c.Close(); err != nil {
 		log.Error().Err(err).Msg("Failed to stop the redis client.")
 	}

--- a/pkg/provider/redis_client_test.go
+++ b/pkg/provider/redis_client_test.go
@@ -120,7 +120,7 @@ func TestRedisClientConcurrentAccess(t *testing.T) {
 func TestRedisClientJobQueue(t *testing.T) {
 	s := miniredis.RunT(t)
 	config := RedisClientConfig{
-		Endpoint:    s.Addr(),
+		Endpoint: s.Addr(),
 	}
 	cache, err := NewRedisClient("test", config)
 	require.NoError(t, err)

--- a/pkg/provider/redis_client_test.go
+++ b/pkg/provider/redis_client_test.go
@@ -24,6 +24,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -114,4 +115,16 @@ func TestRedisClientConcurrentAccess(t *testing.T) {
 
 	close(ch)
 	wg.Wait()
+}
+
+func TestRedisClientJobQueue(t *testing.T) {
+	s := miniredis.RunT(t)
+	config := RedisClientConfig{
+		Endpoint:    s.Addr(),
+	}
+	cache, err := NewRedisClient("test", config)
+	require.NoError(t, err)
+
+	smallItem := strings.Repeat("A", 127)
+	assert.Error(t, ErrRedisJobQueueFull, cache.Store("A", []byte(smallItem), 120*time.Second))
 }

--- a/pkg/provider/remote.go
+++ b/pkg/provider/remote.go
@@ -63,7 +63,7 @@ func (c *remoteCache) Get(ctx context.Context, key string) []byte {
 
 // Set adds an item to the cache.
 func (c *remoteCache) Set(key string, value []byte, ttl time.Duration) {
-	_ = c.client.Store(key, value, ttl)
+	_ = c.client.StoreAsync(key, value, ttl)
 }
 
 // Delete deletes an item from the cache.


### PR DESCRIPTION
This PR adds a job queue to run tasks asynchronously. It is used to store items in the remote cache (e.g. Redis) in an asynchronous way.