### PR TITLE
Add max item size constraint

### DIFF
--- a/kache.sample.yml
+++ b/kache.sample.yml
@@ -50,6 +50,7 @@ provider:
     username:
     password:
     db:
+    max_item_size:
     max_queue_buffer_size:
     max_queue_concurrency:
 

--- a/pkg/provider/cached_test.go
+++ b/pkg/provider/cached_test.go
@@ -36,6 +36,7 @@ func TestCached(t *testing.T) {
 	s := miniredis.RunT(t)
 	client, err := NewRedisClient("redis", RedisClientConfig{
 		Endpoint:            s.Addr(),
+		MaxItemSize:         1 << 14,
 		MaxQueueBufferSize:  32 << 8,
 		MaxQueueConcurrency: 56,
 	})

--- a/pkg/provider/redis_client_test.go
+++ b/pkg/provider/redis_client_test.go
@@ -117,6 +117,22 @@ func TestRedisClientConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRedisClientMaxItemSize(t *testing.T) {
+	s := miniredis.RunT(t)
+	config := RedisClientConfig{
+		Endpoint:    s.Addr(),
+		MaxItemSize: 128,
+	}
+	cache, err := NewRedisClient("test", config)
+	require.NoError(t, err)
+
+	smallItem := strings.Repeat("A", 127)
+	assert.NoError(t, cache.Store("A", []byte(smallItem), 120*time.Second))
+
+	largeItem := strings.Repeat("A", 129)
+	assert.Error(t, ErrRedisMaxItemSize, cache.Store("A", []byte(largeItem), 120*time.Second))
+}
+
 func TestRedisClientJobQueue(t *testing.T) {
 	s := miniredis.RunT(t)
 	config := RedisClientConfig{

--- a/pkg/provider/remote_test.go
+++ b/pkg/provider/remote_test.go
@@ -36,6 +36,7 @@ func TestRedisCache(t *testing.T) {
 	s := miniredis.RunT(t)
 	config := RedisClientConfig{
 		Endpoint:            s.Addr(),
+		MaxItemSize:         1 << 14,
 		MaxQueueBufferSize:  32 << 8,
 		MaxQueueConcurrency: 56,
 	}


### PR DESCRIPTION
This PR adds a `MaxItemSizeConstraint` to Redis items. It must be set via the config.