### PR TITLE
Add IP filter to API

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,7 @@ func (u Upstreams) Validate() error {
 type API struct {
 	Port  int    `yaml:"port"`
 	Path  string `yaml:"path,omitempty"`
+	ACL   string `yaml:"acl,omitempty"`
 	Debug bool   `yaml:"debug,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds a simple IP filter to the API. The access control list can be configured in the config.