### PR TITLE
API: add ability to handle purge requests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,10 +89,10 @@ func (a *API) RegisterRoute(method string, path string, handler http.HandlerFunc
 
 // RegisterProxy registers the cache HTTP service.
 func (a *API) RegisterProxy(p server.Server) {
-	// List cache keys
+	// List all keys in the cache.
 	a.RegisterRoute(http.MethodGet, "/api/cache/keys", a.filter.Wrap(p.CacheKeysHandler))
 	// Delete cache key; /cache/keys/purge?key=...
 	a.RegisterRoute(http.MethodDelete, "/api/cache/keys/purge", a.filter.Wrap((p.CacheKeyDeleteHandler)))
-	// TODO: implement PURGE like this:
-	// curl -v -X PURGE -H 'X-Purge-Regex: ^/assets/*.css' varnishserver:6081
+	// Purge cache key: curl -v -X PURGE -H 'X-Purge-Key: <cache-key>' kacheserver:PORT
+	a.RegisterRoute("PURGE", "/", a.filter.Wrap(p.CacheKeyPurgeHandler))
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -48,3 +48,19 @@ func (s *Server) CacheKeyDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 }
+
+// CacheKeyPurgeHandler handles a PURGE request and deletes the given key from the
+// cache. The cache key is obtained from a custom request header 'X-Purge-Key'.
+func (s *Server) CacheKeyPurgeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "PURGE" {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	// TODO: implement regex header, e.g. 'X-Purge-Regex: ^/assets/*.css'.
+	key := r.Header.Get("X-Purge-Key")
+	if ok := s.cache.Delete(context.Background(), key); !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
This PR adds the ability to handle `PURGE` requests. The cache key is obtained from  a custom request header `X-Purge-Key` and then removed from the cache. E.g., `curl -v -X PURGE -H 'X-Purge-Key: <cache-key>' kacheserver:API-PORT`.