### PR TITLE
Specify default cache control response header

### DIFF
--- a/kache.sample.yml
+++ b/kache.sample.yml
@@ -37,6 +37,8 @@ cache:
   x_header: true
   x_header_name: x-kache
   default_ttl: 120s
+  default_cache_control: "max-age=120s"
+  force_cache_control: false
 
 ## Cache provider configuration
 provider:

--- a/pkg/cache/httpcache.go
+++ b/pkg/cache/httpcache.go
@@ -57,6 +57,12 @@ type HttpCacheConfig struct {
 
 	// Default TTL is the default TTL for cache entries. Overrides 'DefaultTTL'.
 	DefaultTTL string `yaml:"default_ttl"`
+
+	// DefaultCacheControl specifies a default cache-control header.
+	DefaultCacheControl string `yaml:"default_cache_control"`
+
+	// ForceCacheControl specifies whether to overwrite an existing cache-control header.
+	ForceCacheControl bool `yaml:"force_cache_control"`
 }
 
 // HttpCache is the http cache.
@@ -89,6 +95,16 @@ func (c *HttpCache) XCacheHeader() string {
 		return xCache
 	}
 	return c.config.XCacheName
+}
+
+// DefaultCacheControl returns the default cache control.
+func (c *HttpCache) DefaultCacheControl() string {
+	return c.config.DefaultCacheControl
+}
+
+// ForceCacheControl specifies whether to overwrite an existing cache-control header.
+func (c *HttpCache) ForceCacheControl() bool {
+	return c.config.ForceCacheControl
 }
 
 // DefaultTTL returns the TTL as specified in the configuration as a valid duration

--- a/pkg/server/middleware/httpcache.go
+++ b/pkg/server/middleware/httpcache.go
@@ -132,6 +132,9 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		resp = cached.Response()
 	}
 
+	// set or update custom cache control header.
+	updateCacheControl(resp.Header, t.Cache.DefaultCacheControl(), t.Cache.ForceCacheControl())
+
 	// Store new or update validated response.
 	if cache.IsCacheableResponse(resp) && shouldUpdateCachedEntry &&
 		!lookup.ReqCacheControl.NoStore && lookup.Request.Method != "HEAD" {
@@ -193,4 +196,12 @@ func (t *Transport) injectValidationHeaders(ireq *http.Request, header http.Head
 	}
 
 	return req
+}
+
+// updateCacheControl sets or updates the cache-control header.
+func updateCacheControl(header http.Header, val string, force bool) {
+	overwrite := force
+	if _, presentcc := header["Cache-Control"]; !presentcc || overwrite {
+		header["Cache-Control"] = []string{val}
+	}
 }

--- a/pkg/server/middleware/httpcache_test.go
+++ b/pkg/server/middleware/httpcache_test.go
@@ -485,3 +485,19 @@ func TestServeGetFollowedByHead200WithValidation(t *testing.T) {
 		assert.Equal(t, "", resp.Header.Get(XCache))
 	}
 }
+
+func TestUpdateCacheControl(t *testing.T) {
+	h := http.Header{}
+
+	// Set if not present.
+	updateCacheControl(h, "no-store", false)
+	assert.Equal(t, "no-store", h.Get("Cache-Control"))
+
+	// Don't update if present.
+	updateCacheControl(h, "max-age=120", false)
+	assert.Equal(t, "no-store", h.Get("Cache-Control"))
+
+	// Force update.
+	updateCacheControl(h, "max-age=120", true)
+	assert.Equal(t, "max-age=120", h.Get("Cache-Control"))
+}


### PR DESCRIPTION
This PR adds the ability to set or update a response cache-control header with a custom configured cache-control header.