### PR TITLE
Add cache ignore

### DIFF
--- a/kache.sample.yml
+++ b/kache.sample.yml
@@ -49,6 +49,16 @@ cache:
     - path: "^/assets/([a-z0-9].*).css"
       ttl: "120s"
 
+  exclude:
+    path: # applied to request
+      - "^/admin"
+      - "^/.well-known/acme-challenge/(.*)"
+    header: # applied to requests
+      x_requested_with: "XMLHttpRequest"
+    content: # applied to responses
+      - type: "application/javascript|text/css|image/.*"
+        size: 10000 # max size in bytes
+
 ## Cache provider configuration
 provider:
   # activate specified provider backend


### PR DESCRIPTION
This PR adds the ability to exclude specific objects and resources from caching. Excluding can either happen path-based and header-based on the request or based on content type and length on the response. 