### PR TITLE
Remove cache delete endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -103,8 +103,6 @@ func (a *API) RegisterRoute(method string, path string, handler http.HandlerFunc
 func (a *API) RegisterProxy(p server.Server) {
 	// List all keys in the cache.
 	a.RegisterRoute(http.MethodGet, a.prefix+"/cache/keys", a.filter.Wrap(p.CacheKeysHandler))
-	// Delete cache key; /cache/keys/purge?key=...
-	a.RegisterRoute(http.MethodDelete, a.prefix+"/cache/keys/purge", a.filter.Wrap((p.CacheKeyDeleteHandler)))
 	// Purge cache key: curl -v -X PURGE -H 'X-Purge-Key: <cache-key>' kacheserver:PORT
 	a.RegisterRoute("PURGE", "/", a.filter.Wrap(p.CacheKeyPurgeHandler))
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -39,16 +39,6 @@ func (s *Server) CacheKeysHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// CacheKeyPurgeHandler deletes the given key from the cache.
-func (s *Server) CacheKeyDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	key := r.URL.Query().Get("key")
-	if ok := s.cache.Delete(context.Background(), key); !ok {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-}
-
 // CacheKeyPurgeHandler handles a PURGE request and deletes the given key from the
 // cache. The cache key is obtained from a custom request header 'X-Purge-Key'.
 func (s *Server) CacheKeyPurgeHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Remove the cache delete endpoint as it is a duplicate of `PURGE` and we prefer deleting cache keys via the `PURGE` API.