### PR TITLE
Add API to render and update cache config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -125,6 +125,11 @@ func (a *API) createRoutes() {
 		PathPrefix(path.Join(a.prefix, "/cache/keys")).
 		HandlerFunc(a.server.CacheKeysHandler)
 
+	// Render the current cache config.
+	a.router.Methods(http.MethodGet).
+		PathPrefix(path.Join(a.prefix, "/cache/config")).
+		HandlerFunc(a.server.CacheConfigHandler)
+
 	// Flush all keys from the cache.
 	a.router.Methods(http.MethodDelete).
 		PathPrefix(path.Join(a.prefix, "/cache/flush")).

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -130,6 +130,11 @@ func (a *API) createRoutes() {
 		PathPrefix(path.Join(a.prefix, "/cache/config")).
 		HandlerFunc(a.server.CacheConfigHandler)
 
+	// Update the current cache config.
+	a.router.Methods(http.MethodPut).
+		PathPrefix(path.Join(a.prefix, "/cache/config/update")).
+		HandlerFunc(a.server.CacheConfigUpdateHandler)
+
 	// Flush all keys from the cache.
 	a.router.Methods(http.MethodDelete).
 		PathPrefix(path.Join(a.prefix, "/cache/flush")).

--- a/pkg/cache/httpcache.go
+++ b/pkg/cache/httpcache.go
@@ -52,50 +52,50 @@ var DefaultTTL = 120 * time.Second
 type HttpCacheConfig struct {
 	// XCache specifies if the XCache debug header should be attached to responses.
 	// If the response exists in the cache the header value is HIT, MISS otherwise.
-	XCache bool `yaml:"x_header"`
+	XCache bool `yaml:"x_header" json:"x_header"`
 
 	// XCacheName is the name of the X-Cache header.
-	XCacheName string `yaml:"x_header_name"`
+	XCacheName string `yaml:"x_header_name" json:"x_header_name"`
 
 	// Default TTL is the default TTL for cache entries. Overrides 'DefaultTTL'.
-	DefaultTTL string `yaml:"default_ttl"`
+	DefaultTTL string `yaml:"default_ttl" json:"default_ttl"`
 
 	// DefaultCacheControl specifies a default cache-control header.
-	DefaultCacheControl string `yaml:"default_cache_control"`
+	DefaultCacheControl string `yaml:"default_cache_control" json:"default_cache_control"`
 
 	// ForceCacheControl specifies whether to overwrite an existing cache-control header.
-	ForceCacheControl bool `yaml:"force_cache_control"`
+	ForceCacheControl bool `yaml:"force_cache_control" json:"force_cache_control"`
 
 	// Timeouts holds the TTLs per path/resource.
-	Timeouts []Timeout `yaml:"timeouts"`
+	Timeouts []Timeout `yaml:"timeouts" json:"timeouts"`
 
 	// Exclude contains the cache exclude configuration.
-	Exclude *Exclude `yaml:"exclude"`
+	Exclude *Exclude `yaml:"exclude" json:"exclude"`
 }
 
 // Timeout holds the custom TTL configuration
 type Timeout struct {
 	// Path is the path the ttl is applied to. String or Regex.
-	Path string `yaml:"path"`
+	Path string `yaml:"path" json:"path"`
 	// TTL is the corresponing resource ttl.
-	TTL time.Duration `yaml:"ttl"`
+	TTL time.Duration `yaml:"ttl" json:"ttl"`
 	// Matcher holds the compiled regex.
-	Matcher *regexp.Regexp
+	Matcher *regexp.Regexp `json:"-"`
 }
 
 // Exclude holds the cache ignore information.
 type Exclude struct {
 	// Path contains the paths to be ignored by the cache.
-	Path []string `yaml:"path"`
+	Path []string `yaml:"path" json:"path"`
 
 	// PathMatcher contains the compile `Path` patterns.
-	PathMatcher []*regexp.Regexp
+	PathMatcher []*regexp.Regexp `json:"-"`
 
 	// Header contains the headers to be ignored by the cache.
-	Header map[string]string `yaml:"header"`
+	Header map[string]string `yaml:"header" json:"header"`
 
 	// Content contains the content types to be ignored by the cache.
-	Content []Content `yaml:"content"`
+	Content []Content `yaml:"content" json:"content"`
 }
 
 // Content holds the specific content-type and max content size used for excluding responses from
@@ -104,13 +104,13 @@ type Exclude struct {
 // to cache the response or not.
 type Content struct {
 	// Type is the content type to be ignored by the cache.
-	Type string `yaml:"type"`
+	Type string `yaml:"type" json:"type"`
 
 	// TypeMatcher contains the compiled `Type` patterns.
-	TypeMatcher *regexp.Regexp
+	TypeMatcher *regexp.Regexp `json:"-"`
 
 	// Size is the max content size in bytes.
-	Size int `yaml:"size,omitempty"`
+	Size int `yaml:"size,omitempty" json:"size,omitempty"`
 }
 
 // HttpCache is the http cache.
@@ -129,6 +129,11 @@ func NewHttpCache(config *HttpCacheConfig, pdr provider.Provider) (*HttpCache, e
 		cfg = config
 
 	}
+
+// Config returns the current cache config.
+func (c *HttpCache) Config() *HttpCacheConfig {
+	return c.config
+}
 
 	// Compile custom timeout matchers.
 	for i, t := range cfg.Timeouts {

--- a/pkg/cache/httpcache.go
+++ b/pkg/cache/httpcache.go
@@ -129,41 +129,50 @@ func NewHttpCache(config *HttpCacheConfig, pdr provider.Provider) (*HttpCache, e
 		cfg = config
 
 	}
+	c := &HttpCache{
+		cache: pdr,
+	}
+	c.UpdateConfig(cfg)
+	return c, nil
+}
 
 // Config returns the current cache config.
 func (c *HttpCache) Config() *HttpCacheConfig {
 	return c.config
 }
 
+// UpdateConfig updates the cache config.
+func (c *HttpCache) UpdateConfig(config *HttpCacheConfig) {
 	// Compile custom timeout matchers.
-	for i, t := range cfg.Timeouts {
+	for i, t := range config.Timeouts {
 		r, err := regexp.Compile(t.Path)
 		if err != nil {
 			log.Error().Err(err).Str("path", t.Path).Msg("Invalid timeout path regex")
 		}
-		cfg.Timeouts[i].Matcher = r
+		config.Timeouts[i].Matcher = r
 	}
 
 	// Compile cache exclude matchers.
-	if cfg.Exclude != nil {
-		cfg.Exclude.PathMatcher = make([]*regexp.Regexp, len(cfg.Exclude.Path))
-		for i, p := range cfg.Exclude.Path {
+	if config.Exclude != nil {
+		config.Exclude.PathMatcher = make([]*regexp.Regexp, len(config.Exclude.Path))
+		for i, p := range config.Exclude.Path {
 			r, err := regexp.Compile(p)
 			if err != nil {
 				log.Error().Err(err).Str("path", p).Msg("Invalid exclude path regex")
 			}
-			cfg.Exclude.PathMatcher[i] = r
+			config.Exclude.PathMatcher[i] = r
 		}
-		for i, c := range cfg.Exclude.Content {
-			r, err := regexp.Compile(c.Type)
+		for i, co := range config.Exclude.Content {
+			r, err := regexp.Compile(co.Type)
 			if err != nil {
-				log.Error().Err(err).Str("content", c.Type).Msg("Invalid exclude content type regex")
+				log.Error().Err(err).Str("content", co.Type).Msg("Invalid exclude content type regex")
 			}
-			cfg.Exclude.Content[i].TypeMatcher = r
+			config.Exclude.Content[i].TypeMatcher = r
 		}
 	}
 
-	return &HttpCache{cfg, pdr}, nil
+	c.config = config
+
 }
 
 // IsExcludedPath checks wether a specific path is excluded from caching.

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 
 	"github.com/kacheio/kache/pkg/cache"
+	"gopkg.in/yaml.v3"
 )
 
 // CacheKeysHandler renders all cache keys in JSON format.
@@ -78,4 +79,16 @@ func (s *Server) CacheConfigHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+}
+
+// CacheConfigHandler renders the current cache config.
+func (s *Server) CacheConfigUpdateHandler(w http.ResponseWriter, r *http.Request) {
+	var c cache.HttpCacheConfig
+	dec := yaml.NewDecoder(r.Body)
+	if err := dec.Decode(&c); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.httpcache.UpdateConfig(&c)
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -27,6 +27,8 @@ import (
 	"encoding/json"
 
 	"net/http"
+
+	"github.com/kacheio/kache/pkg/cache"
 )
 
 // CacheKeysHandler renders all cache keys in JSON format.
@@ -66,4 +68,14 @@ func (s *Server) CacheFlushHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+// CacheConfigHandler renders the current cache config.
+func (s *Server) CacheConfigHandler(w http.ResponseWriter, r *http.Request) {
+	config := s.httpcache.Config()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(config); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 }


### PR DESCRIPTION
This PR adds the ability to render and update the current cache configuration. Updating the cache configuration via the API only updates the runtime configuration and does not keep the changes in the specified configuration file. Therefore, the changes are not preserved when the service is restarted.