### PR TITLE
Switch config to use atomic.Pointer

### DIFF
--- a/pkg/cache/httpcache_test.go
+++ b/pkg/cache/httpcache_test.go
@@ -285,12 +285,8 @@ func TestHttpCacheDefaultConfig(t *testing.T) {
 	c, err := NewHttpCache(nil, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", c.config.DefaultTTL)
 	assert.Equal(t, time.Duration(DefaultTTL), c.DefaultTTL())
-
-	assert.Equal(t, false, c.config.XCache)
 	assert.Equal(t, xCache, c.XCacheHeader())
-
 	assert.Equal(t, false, c.MarkCachedResponses())
 }
 
@@ -299,7 +295,6 @@ func TestHttpCacheDefaultTTL(t *testing.T) {
 		DefaultTTL: "3600s",
 	}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "3600s", c.config.DefaultTTL)
 	assert.Equal(t, time.Duration(3600*time.Second), c.DefaultTTL())
 }
 


### PR DESCRIPTION
This updates the cache configuration in a concurrent safe way. There are no significant performance changes when using `atomic.Pointer` to synchronize access to the configuration: `10.82 ns/op` vs. `11.58 ns/op`.

### Benchmarks

```shell
goos: darwin
goarch: amd64
pkg: github.com/kacheio/kache/pkg/cache
cpu: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
    │ no_sync.txt │              mutex.txt               │          atomic_value.txt          │         atomic_pointer.txt          │
    │   sec/op    │   sec/op     vs base                 │   sec/op     vs base               │    sec/op     vs base               │
N-4   10.82n ± 1%   25.01n ± 2%  +130.99% (p=0.000 n=10)   11.90n ± 1%  +9.93% (p=0.000 n=10)   11.58n ± 10%  +6.97% (p=0.001 n=10)

``` 