### PR TITLE
Add ability to auto-reload the configuration file

### DIFF
--- a/cmd/kache/main.go
+++ b/cmd/kache/main.go
@@ -26,6 +26,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/kacheio/kache/pkg/config"
 	"github.com/kacheio/kache/pkg/kache"
@@ -35,8 +36,11 @@ import (
 )
 
 const (
-	configFileOption = "config.file"
-	configFileName   = "kache.yml"
+	configFileName = "kache.yml"
+
+	configFileOption          = "config.file"
+	configAutoReloadOption    = "config.auto-reload"
+	configWatchIntervalOption = "config.watch-interval"
 
 	versionOption = "version"
 	versionUsage  = "Print application version and exit."
@@ -49,6 +53,12 @@ func main() {
 	var printVersion bool
 	flag.BoolVar(&printVersion, versionOption, false, versionUsage)
 
+	var configAutoReload bool
+	flag.BoolVar(&configAutoReload, configAutoReloadOption, false, "")
+
+	var configWatchInterval time.Duration
+	flag.DurationVar(&configWatchInterval, configWatchIntervalOption, 10*time.Second, "")
+
 	var configFile string
 	flag.StringVar(&configFile, configFileOption, configFileName, "")
 
@@ -60,7 +70,7 @@ func main() {
 	}
 
 	// Load config file.
-	ldr, err := config.NewFileLoader(configFile)
+	ldr, err := config.NewLoader(configFile, configAutoReload, configWatchInterval)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error loading config from %s: %v\n", configFile, err)
 		os.Exit(1)


### PR DESCRIPTION
This PR adds the ability to automatically reload the configuration file. Automatic reloading can be enabled at service startup via the `-config.auto-reload` flag . If enabled, Kache will watch the specified configuration file for changes and automatically reload the configuration if it has changed. The watch interval can be specified with the `-config.watch-interval=<duration>` flag, where `<duration>` must be a valid duration, e.g. `5s`. If no watch interval is specified, the default watch interval is `10s`.

