### PR TITLE
Add ability to coalesce requests

### DIFF
--- a/pkg/server/middleware/coalesce.go
+++ b/pkg/server/middleware/coalesce.go
@@ -1,0 +1,161 @@
+// MIT License
+//
+// Copyright (c) 2023 kache.io
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package middleware
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// requestCoalescer allows concurrent requests for the same URL to share
+// a single upstream request and response. Once a request is received for
+// processing for the first time, it will execute a HTTP transaction, obtaining
+// a response for a given request. If a duplicate request (same URL) comes in
+// at the same time, those threads will wait for the original to complete and receive
+// the same results. The original request's response is copied into the waiting
+// threads, which will then resume their execution.
+type requestCoalescer struct {
+	sync.Mutex
+	inflights map[string]*call
+
+	// next holds a RoundTripper that executes a single HTTP
+	// transaction, obtaining a response for a given request.
+	next http.RoundTripper
+}
+
+// call is an in-flight or completed singleflight request.
+type call struct {
+	*sync.Cond // rendezvous point for goroutines.
+
+	// coalesced indicates if there are any calls waiting
+	// for the initial in-flight request's response.
+	coalesced bool
+	resp      []byte
+	err       error
+}
+
+// NewCoalesced returns a coalesced http roundtripper.
+func NewCoalesced(next http.RoundTripper) http.RoundTripper {
+	return &requestCoalescer{
+		inflights: make(map[string]*call),
+		next:      next,
+	}
+}
+
+// RoundTrip executes and returns the given request and coalesces
+// concurrent GET requests. It ensures that only one execution call is
+// in-flight for a given key at a time. Following duplicate or similar (same URL)
+// requests are blocked until the original request completes. The resulting
+// response is shared with all waiting requests.
+func (coalescer *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only coalesce GET requests.
+	if req.Method != http.MethodGet {
+		return coalescer.next.RoundTrip(req)
+	}
+
+	key := req.URL.String()
+	coalescer.Lock()
+	inflight, ok := coalescer.inflights[key]
+	if ok {
+		// At this point a similar request is already in-flight. Wait for response.
+
+		// Close the request body, as this request is put on hold here waiting for
+		// the initial request's response.
+		if req.Body != nil {
+			defer req.Body.Close()
+		}
+
+		// Lock the inflight request to prevent it from being removed before
+		// any waiting call routines are done processing.
+		inflight.L.Lock()
+
+		// Unlock the coalescer to allow other requests to use it.
+		// Important: the inflight call must be locked before to
+		// guarantee no other thread can delete it.
+		coalescer.Unlock()
+
+		// Mark that there is at least one call awaiting a shared response.
+		inflight.coalesced = true
+
+		// Suspend execution of current thread until inflight request is processed.
+		inflight.Wait()
+
+		// Resume execution of waiting thread (woken up by initial thread broadcast).
+		inflight.L.Unlock()
+
+		// Initial request completed.
+		if inflight.err != nil {
+			return nil, inflight.err
+		}
+		// Copy initial response to waiting caller.
+		resp, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(inflight.resp)), nil)
+		if err != nil {
+			log.Error().Err(err).Str("key", key).Msg("Error loading response")
+			return nil, err
+		}
+		return resp, nil
+	}
+
+	// No similar request in flight (common case).
+
+	// Register a new call and execute the request.
+	inflight = &call{Cond: sync.NewCond(&sync.Mutex{})}
+	coalescer.inflights[key] = inflight
+	coalescer.Unlock()
+
+	// Execute e2e request.
+	resp, err := coalescer.next.RoundTrip(req)
+
+	// Upstream response received. Remove inflight request from the map.
+	// Important: Removing the inflight request before waking up waiting
+	// calls is crucial, otherwise race conditions and memory leaks occur.
+	coalescer.Lock()
+	delete(coalescer.inflights, key)
+	coalescer.Unlock()
+
+	// Wake up any suspended callers waiting for this response.
+	inflight.L.Lock()
+	if inflight.coalesced {
+		if err != nil {
+			inflight.resp, inflight.err = nil, err
+		} else {
+			// Copy the response before releasing it to waiter(s).
+			inflight.resp, inflight.err = httputil.DumpResponse(resp, true)
+		}
+		// Wake up all waiting routines.
+		inflight.Broadcast()
+	}
+	inflight.L.Unlock()
+
+	if err != nil {
+		log.Error().Err(err).Str("key", key).Send()
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pkg/server/middleware/coalesce_test.go
+++ b/pkg/server/middleware/coalesce_test.go
@@ -1,0 +1,144 @@
+// MIT License
+//
+// Copyright (c) 2023 kache.io
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upstream is the test transport holding a request counter that gets
+// incremented on each request hitting the upstream. Depending on the 
+// `Coalesced` http request header, it either responds instantly or 
+// supends its operation until signaled to resume.
+type upstream struct {
+	wait chan struct{}
+
+	mu   sync.Mutex
+	hits map[string]int
+}
+
+func (t *upstream) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.hits[req.URL.Path] += 1
+	t.mu.Unlock()
+
+	if _, ok := req.Header["Coalesced"]; ok {
+		<-t.wait
+	}
+
+	return &http.Response{
+		Body: io.NopCloser(bytes.NewBufferString(req.URL.Path)),
+	}, nil
+}
+
+func TestCoalescedRoundTrip(t *testing.T) {
+	// For concurrent requests to the same resource,
+	// only 1 request should hit the upstream.
+
+	upstream := &upstream{
+		hits: make(map[string]int),
+		wait: make(chan struct{}),
+	}
+	coalesced := NewCoalesced(upstream)
+
+	n := 100
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := doRequest(t, coalesced, "/coalesced", true)
+			require.NoError(t, err)
+		}()
+	}
+
+	// Add some grace time to wait for all requests to be made.
+	time.Sleep(100 * time.Millisecond)
+
+	// Requests to other resources should not be blocked.
+	_, err := doRequest(t, coalesced, "/non-coalesced", false)
+	require.NoError(t, err)
+
+	// Resume upstream processing.
+	close(upstream.wait)
+
+	// Singleflight requests should all hit the upstream.
+	_, err = doRequest(t, coalesced, "/non-coalesced", false)
+	require.NoError(t, err)
+
+	wg.Wait()
+
+	expected := map[string]int{
+		"/coalesced":     1,
+		"/non-coalesced": 2,
+	}
+	assert.Equal(t, expected, upstream.hits)
+}
+
+//nolint:revive
+func doRequest(t *testing.T, rt http.RoundTripper, path string, coalesced bool) (*http.Response, error) {
+	u, err := url.Parse("http://test.com" + path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if coalesced {
+		req.Header.Set("coalesced", "1")
+	}
+
+	done := make(chan struct{})
+	var resp *http.Response
+	go func() {
+		defer close(done)
+		resp, err = rt.RoundTrip(req)
+		if err == nil {
+			if body, ioErr := io.ReadAll(resp.Body); ioErr != nil {
+				err = ioErr
+			} else if string(body) != path {
+				err = errors.New("unexpected response value")
+			}
+		}
+	}()
+
+	select {
+	case <-time.After(3 * time.Second):
+		return nil, fmt.Errorf("request for %q timed out", path)
+	case <-done:
+		return resp, err
+	}
+}

--- a/pkg/server/middleware/coalesce_test.go
+++ b/pkg/server/middleware/coalesce_test.go
@@ -38,8 +38,8 @@ import (
 )
 
 // upstream is the test transport holding a request counter that gets
-// incremented on each request hitting the upstream. Depending on the 
-// `Coalesced` http request header, it either responds instantly or 
+// incremented on each request hitting the upstream. Depending on the
+// `Coalesced` http request header, it either responds instantly or
 // supends its operation until signaled to resume.
 type upstream struct {
 	wait chan struct{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,11 +91,13 @@ func NewServer(cfg *config.Configuration, httpcache *cache.HttpCache) (*Server, 
 	}
 	srv.listeners = listeners
 
+	transport := middleware.NewCoalesced(middleware.NewCachedTransport(srv.httpcache))
+
 	// Create the reverse proxy.
 	proxy := &httputil.ReverseProxy{
 		ErrorHandler: errorHandler,
 		Director:     srv.Director(),
-		Transport:    middleware.NewCachedTransport(srv.httpcache),
+		Transport:    transport,
 	}
 	srv.proxy = proxy
 


### PR DESCRIPTION
This PR adds the ability to coalesce duplicate requests. 

Concurrent requests for the same resource are coalesced and share a single upstream request/response, instead of each request resulting in a corresponding upstream request and response. 

Request coalescing is particularly useful for use cases where the same resource is requested multiple times in rapid succession.  For example, under very heavy load, when a cached version of a popular page expires, there may be multiple execution threads attempting to render the content of that page at the same time, potentially leading to a cascading failure and [congestion collapse](https://en.wikipedia.org/wiki/Network_congestion#Congestive_collapse), also know as cache stampede. Coalescing requests prevents [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede) and mitigates the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem) by making only a single request to the upstream  per expired/missing key, regardless of the number of requests to that key.


