### PR TITLE
Update lint and make

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - gofmt
+    - gofumpt
     - goimports
     - gosimple
     - revive

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ GO_FLAGS := -ldflags "\
 
 TEST_TIMEOUT := 20m 
 
+.PHONY: all help verify check lint format test test-with-race mod mod-check mod-update mod-vendor clean license license-check release snap-release run build build-run
+
+help: ## Print help.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 verify: lint license-check mod-check ## Verify source (code, licencse, modules). 
 
 check: verify test-with-race build ## Check the build (lint, test, build).

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ GO_FLAGS := -ldflags "\
 
 TEST_TIMEOUT := 20m 
 
-.PHONY: all lint format test test-with-race mod mod-check mod-update mod-vendor clean license license-check release snap-release run build build-run
+verify: lint license-check mod-check ## Verify source (code, licencse, modules). 
+
+check: verify test-with-race build ## Check the build (lint, test, build).
 
 lint: ## Run linters.
 	@printf $(COLOR) "Run linters..."
@@ -29,7 +31,7 @@ format: ## Run gofmt.
 	@printf $(COLOR) "Run formatters..."
 	@gofmt -s -l -w $(SRCS)
 
-test: ## Run all tests.
+test: ## Run all unit tests.
 	@go test -timeout=$(TEST_TIMEOUT) ./...
 
 test-with-race: ## Run all unit tests with data race detect.


### PR DESCRIPTION
Enables `gofumpt` in linter and adds `verify`, `check`, and `help` commands to `Makefile`.