### PR TITLE
Add cache mode

### DIFF
--- a/pkg/cache/httpcache.go
+++ b/pkg/cache/httpcache.go
@@ -51,6 +51,12 @@ var DefaultTTL = 120 * time.Second
 
 // HttpCacheConfig holds the http cache configuration.
 type HttpCacheConfig struct {
+	// Strict specifies the cache mode. When strict mode is enabled (default), the http cache
+	// respects the directives set in the Cache-Control header. If disabled (cache mode all),
+	// the http cache ignores the Cache-Control directives and stores every response until it
+	// is expired by its TTL (time-to-live).
+	Strict bool `yaml:"strict" json:"strict"`
+
 	// XCache specifies if the XCache debug header should be attached to responses.
 	// If the response exists in the cache the header value is HIT, MISS otherwise.
 	XCache bool `yaml:"x_header" json:"x_header"`
@@ -125,7 +131,7 @@ type HttpCache struct {
 
 // NewHttpCache creates a new http cache.
 func NewHttpCache(config *HttpCacheConfig, pdr provider.Provider) (*HttpCache, error) {
-	cfg := &HttpCacheConfig{}
+	cfg := &HttpCacheConfig{Strict: true}
 	if config != nil {
 		cfg = config
 
@@ -181,6 +187,12 @@ func (c *HttpCache) UpdateConfig(config *HttpCacheConfig) {
 
 	// Safely update config.
 	c.config.Store(config)
+}
+
+// Strict returns true if the cache mode is `strict`.
+func (c *HttpCache) Strict() bool {
+	config := c.loadConfig()
+	return config.Strict
 }
 
 // IsExcludedPath checks whether a specific path is excluded from caching.

--- a/pkg/server/middleware/httpcache.go
+++ b/pkg/server/middleware/httpcache.go
@@ -91,7 +91,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		return t.send(req)
 	}
 
-	lookup := cache.NewLookupRequest(req, t.currentTime())
+	lookup := cache.NewLookupRequest(req, t.currentTime(), t.Cache.Strict())
 	cacheKey := lookup.Key.String()
 
 	log.Debug().Str("cache-key", cacheKey).Msg("Lookup response")
@@ -142,12 +142,12 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		resp = cached.Response()
 	}
 
-	// set or update custom cache control header.
+	// Set or update custom cache control header.
 	updateCacheControl(resp.Header, t.Cache.DefaultCacheControl(), t.Cache.ForceCacheControl())
 
 	// Store new or update validated response.
-	if cache.IsCacheableResponse(resp) && shouldUpdateCachedEntry &&
-		!lookup.ReqCacheControl.NoStore && lookup.Request.Method != "HEAD" &&
+	if (!t.Cache.Strict() || (cache.IsCacheableResponse(resp) && shouldUpdateCachedEntry &&
+		!lookup.ReqCacheControl.NoStore)) && lookup.Request.Method != "HEAD" &&
 		!t.Cache.IsExcludedContent(resp.Header.Get("Content-Type"), resp.ContentLength) {
 		t.Cache.StoreResponse(context.Background(), lookup, resp, t.currentTime())
 	} else {


### PR DESCRIPTION
This PR adds the ability to change the cache mode. It introduces a `strict` flag in the HTTP cache configuration that specifies the cache mode. When strict mode is enabled (default), the HTTP cache respects the directives set in the Cache-Control header. When disabled (cache mode: all), the HTTP cache ignores the Cache-Control directives, skips any validation based on the Cache-Control header, and stores each response until its TTL (time-to-live) expires.
