### PR TITLE
Add http cache metrics

### DIFF
--- a/pkg/kache/kache.go
+++ b/pkg/kache/kache.go
@@ -55,8 +55,8 @@ type Kache struct {
 // New makes a new Kache.
 func New(loader *config.Loader, registerer prometheus.Registerer) (*Kache, error) {
 	kache := &Kache{
-		loader: loader,
-		Config: loader.Config(),
+		loader:     loader,
+		Config:     loader.Config(),
 		Registerer: registerer,
 	}
 
@@ -78,7 +78,7 @@ func (t *Kache) initAPI() (err error) {
 
 // initServer initializes the core server.
 func (t *Kache) initServer() (err error) {
-	t.Server, err = server.NewServer(t.Config, *t.Provider, t.Cache)
+	t.Server, err = server.NewServer(t.Config, *t.Provider, t.Cache, t.Registerer)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/middleware/httpcache_test.go
+++ b/pkg/server/middleware/httpcache_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kacheio/kache/pkg/cache"
 	"github.com/kacheio/kache/pkg/provider"
 	"github.com/kacheio/kache/pkg/utils/clock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,7 +77,7 @@ func setup(t *testing.T) {
 		XCache:     true,
 		XCacheName: XCache,
 	}, p)
-	tp := NewCachedTransport(h)
+	tp := NewCachedTransport(h, prometheus.NewRegistry())
 	tp.currentTime = currentTime
 
 	client := http.Client{Transport: tp}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kacheio/kache/pkg/cache"
 	"github.com/kacheio/kache/pkg/config"
 	"github.com/kacheio/kache/pkg/provider"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,7 @@ func TestProxyNoHost(t *testing.T) {
 	}
 	p, _ := provider.NewSimpleCache(nil)
 	c, _ := cache.NewHttpCache(nil, p)
-	proxy, _ := NewServer(cfg, p, c)
+	proxy, _ := NewServer(cfg, p, c, prometheus.NewRegistry())
 	proxyServer := httptest.NewServer(proxy)
 	defer proxyServer.Close()
 
@@ -81,7 +82,7 @@ func TestProxySingleHost(t *testing.T) {
 	}
 	p, _ := provider.NewSimpleCache(nil)
 	c, _ := cache.NewHttpCache(nil, p)
-	proxy, _ := NewServer(cfg, p, c)
+	proxy, _ := NewServer(cfg, p, c, prometheus.NewRegistry())
 	proxyServer := httptest.NewServer(proxy)
 	defer proxyServer.Close()
 
@@ -123,7 +124,7 @@ func TestProxyMultiHost(t *testing.T) {
 	}
 	p, _ := provider.NewSimpleCache(nil)
 	c, _ := cache.NewHttpCache(nil, p)
-	proxy, _ := NewServer(cfg, p, c)
+	proxy, _ := NewServer(cfg, p, c, prometheus.NewRegistry())
 	proxyServer := httptest.NewServer(proxy)
 	defer proxyServer.Close()
 
@@ -159,7 +160,7 @@ func TestProxyMultiListener(t *testing.T) {
 	}
 	p, _ := provider.NewSimpleCache(nil)
 	c, _ := cache.NewHttpCache(nil, p)
-	proxy, _ := NewServer(cfg, p, c)
+	proxy, _ := NewServer(cfg, p, c, prometheus.NewRegistry())
 	proxy.Start(context.Background())
 	defer proxy.Stop()
 


### PR DESCRIPTION
This adds first http cache metrics, total requests partitioned by hits and misses. More metrics will follow.