### PR TITLE
Broadcast config update events in a cluster

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,7 +39,7 @@ type Config struct {
 // Connection is the cluster connection interface.
 type Connection interface {
 	Endpoints(portname string) []Endpoint
-	Broadcast(req *http.Request, portname string, path string)
+	Broadcast(req *http.Request, method, portname, path string)
 	Close()
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,7 +39,7 @@ type Config struct {
 // Connection is the cluster connection interface.
 type Connection interface {
 	Endpoints(portname string) []Endpoint
-	Broadcast(req *http.Request, method, portname, path string)
+	Broadcast(req *http.Request, portname, method, path string)
 	Close()
 }
 


### PR DESCRIPTION
This PR adds the ability to send configuration update events to nodes in a cluster. The configuration is not reloaded, but only temporary configuration changes made via the API are forwarded.